### PR TITLE
chore: adjust traces schema order

### DIFF
--- a/src/servers/src/otlp/trace/span.rs
+++ b/src/servers/src/otlp/trace/span.rs
@@ -14,8 +14,6 @@
 
 use std::fmt::Display;
 
-use api::v1::value::ValueData;
-use api::v1::ColumnDataType;
 use common_time::timestamp::Timestamp;
 use itertools::Itertools;
 use opentelemetry_proto::tonic::common::v1::{InstrumentationScope, KeyValue};
@@ -48,8 +46,6 @@ pub struct TraceSpan {
     pub span_links: SpanLinks,       // TODO(yuanbohan): List in the future
     pub start_in_nanosecond: u64,    // this is also the Timestamp Index
     pub end_in_nanosecond: u64,
-
-    pub uplifted_span_attributes: Vec<(String, ColumnDataType, ValueData)>,
 }
 
 pub type TraceSpans = Vec<TraceSpan>;
@@ -221,8 +217,6 @@ pub fn parse_span(
 
         start_in_nanosecond: span.start_time_unix_nano,
         end_in_nanosecond: span.end_time_unix_nano,
-
-        uplifted_span_attributes: vec![],
     }
 }
 

--- a/src/servers/src/otlp/utils.rs
+++ b/src/servers/src/otlp/utils.rs
@@ -14,6 +14,8 @@
 
 use std::collections::BTreeMap;
 
+use api::v1::value::ValueData;
+use api::v1::ColumnDataType;
 use itertools::Itertools;
 use jsonb::{Number as JsonbNumber, Value as JsonbValue};
 use opentelemetry_proto::tonic::common::v1::{any_value, KeyValue};
@@ -57,4 +59,21 @@ pub fn key_value_to_jsonb(key_values: Vec<KeyValue>) -> JsonbValue<'static> {
         map.insert(kv.key.clone(), value);
     }
     JsonbValue::Object(map)
+}
+
+#[inline]
+pub(crate) fn make_string_column_data(
+    name: &str,
+    value: String,
+) -> (String, ColumnDataType, ValueData) {
+    make_column_data(name, ColumnDataType::String, ValueData::StringValue(value))
+}
+
+#[inline]
+pub(crate) fn make_column_data(
+    name: &str,
+    data_type: ColumnDataType,
+    value: ValueData,
+) -> (String, ColumnDataType, ValueData) {
+    (name.to_string(), data_type, value)
 }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1594,7 +1594,7 @@ pub async fn test_otlp_traces(store_type: StorageType) {
     assert_eq!(StatusCode::OK, res.status());
 
     // select traces data
-    let expected = r#"[["b5e5fb572cf0a3335dd194a14145fef5","3364d2da58c9fd2b","",{"service.name":"telemetrygen"},{},{"net.peer.ip":"1.2.3.4","peer.service":"telemetrygen-server"},[],[],"telemetrygen","","","lets-go","SPAN_KIND_CLIENT","STATUS_CODE_UNSET","",1726631197820927000,1726631197821050000,0.123,1726631197820927000],["b5e5fb572cf0a3335dd194a14145fef5","74c82efa6f628e80","3364d2da58c9fd2b",{"service.name":"telemetrygen"},{},{"net.peer.ip":"1.2.3.4","peer.service":"telemetrygen-client"},[],[],"telemetrygen","","","okey-dokey-0","SPAN_KIND_SERVER","STATUS_CODE_UNSET","",1726631197820927000,1726631197821050000,0.123,1726631197820927000]]"#;
+    let expected = r#"[[1726631197820927000,1726631197821050000,123000,"b5e5fb572cf0a3335dd194a14145fef5","3364d2da58c9fd2b","","SPAN_KIND_CLIENT","lets-go","STATUS_CODE_UNSET","","",{"net.peer.ip":"1.2.3.4","peer.service":"telemetrygen-server"},[],[],"telemetrygen","",{},{"service.name":"telemetrygen"}],[1726631197820927000,1726631197821050000,123000,"b5e5fb572cf0a3335dd194a14145fef5","74c82efa6f628e80","3364d2da58c9fd2b","SPAN_KIND_SERVER","okey-dokey-0","STATUS_CODE_UNSET","","",{"net.peer.ip":"1.2.3.4","peer.service":"telemetrygen-client"},[],[],"telemetrygen","",{},{"service.name":"telemetrygen"}]]"#;
     validate_data(
         "otlp_traces",
         &client,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr does
1. re-order the schema of trace table
    - rename `greptime_timestamp` to `timestamp`, and remove `start` as it's virtually `timestamp`
    - rename `end` to `timestamp_end`
    - rename `greptime_value` to `duration_nano` and use nano-second resolution
2. remove `uplifted_span_attributes` as it's not used by now

previous it's 
```
resource_attributes: {"service.name":"telemetrygen"}
   scope_attributes: {}
    span_attributes: {"net.peer.ip":"1.2.3.4","peer.service":"telemetrygen-server"}
        span_events: []
         span_links: []
         scope_name: telemetrygen
      scope_version:
        trace_state:
          span_name: lets-go
          span_kind: SPAN_KIND_CLIENT
   span_status_code: STATUS_CODE_UNSET
span_status_message:
              start: 2024-11-06 06:22:27.165664
                end: 2024-11-06 06:22:27.165787
     greptime_value: 0.123
 greptime_timestamp: 2024-11-06 06:22:27.165664
```

current schema order looks like this
```
mysql> desc table opentelemetry_traces;
+---------------------+---------------------+------+------+---------+---------------+
| Column              | Type                | Key  | Null | Default | Semantic Type |
+---------------------+---------------------+------+------+---------+---------------+
| timestamp           | TimestampNanosecond | PRI  | NO   |         | TIMESTAMP     |
| timestamp_end       | TimestampNanosecond |      | YES  |         | FIELD         |
| duration_nano       | UInt64              |      | YES  |         | FIELD         |
| trace_id            | String              | PRI  | YES  |         | TAG           |
| span_id             | String              | PRI  | YES  |         | TAG           |
| parent_span_id      | String              | PRI  | YES  |         | TAG           |
| span_kind           | String              |      | YES  |         | FIELD         |
| span_name           | String              |      | YES  |         | FIELD         |
| span_status_code    | String              |      | YES  |         | FIELD         |
| span_status_message | String              |      | YES  |         | FIELD         |
| trace_state         | String              |      | YES  |         | FIELD         |
| span_attributes     | Json                |      | YES  |         | FIELD         |
| span_events         | Json                |      | YES  |         | FIELD         |
| span_links          | Json                |      | YES  |         | FIELD         |
| scope_name          | String              |      | YES  |         | FIELD         |
| scope_version       | String              |      | YES  |         | FIELD         |
| scope_attributes    | Json                |      | YES  |         | FIELD         |
| resource_attributes | Json                |      | YES  |         | FIELD         |
+---------------------+---------------------+------+------+---------+---------------+

mysql> select * from opentelemetry_traces limit 1 \G
*************************** 1. row ***************************
          timestamp: 2024-11-06 09:00:08.683361
      timestamp_end: 2024-11-06 09:00:08.683484
      duration_nano: 123000
           trace_id: 00199db0d11280be936dcebca7ba9242
            span_id: 780762eca93c875b
     parent_span_id: ee86ff781d286405
          span_kind: SPAN_KIND_SERVER
          span_name: okey-dokey-0
   span_status_code: STATUS_CODE_UNSET
span_status_message:
        trace_state:
    span_attributes: {"net.peer.ip":"1.2.3.4","peer.service":"telemetrygen-client"}
        span_events: []
         span_links: []
         scope_name: telemetrygen
      scope_version:
   scope_attributes: {}
resource_attributes: {"service.name":"telemetrygen"}
1 row in set (0.01 sec)
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
